### PR TITLE
Add randomizer mutation and stats tracking

### DIFF
--- a/app/randomizer/page.tsx
+++ b/app/randomizer/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+
+const PLATFORM_KEYS = [
+  "gumroadUrl",
+  "etsyUrl",
+  "creativeMarketUrl",
+  "notionUrl",
+  "notionery",
+  "notionEverything",
+  "prototion",
+  "notionLand",
+] as const;
+
+export default function RandomizerPage() {
+  const randomize = useMutation(api.randomizer.randomize);
+  const recent = useQuery(api.randomizer.recentStats, { limit: 20 }) || [];
+  const summary = useQuery(api.randomizer.summaryStats) || [];
+  const [current, setCurrent] = useState<any>(null);
+
+  const run = async () => {
+    const result = await randomize();
+    setCurrent(result);
+  };
+
+  const platform =
+    current &&
+    PLATFORM_KEYS.map((k) => (current as any)[k]).find((v) => v != null);
+
+  const score =
+    current &&
+    (recent.find((r: any) => r.product._id === current._id)?.count || 0);
+
+  return (
+    <div>
+      <button onClick={run}>Randomize</button>
+      {current && (
+        <div>
+          <h2>{current.listingName}</h2>
+          {platform && (
+            <p>
+              Platform: <a href={platform}>{platform}</a>
+            </p>
+          )}
+          <p>Score (last 20): {score}</p>
+        </div>
+      )}
+      <h3>Health</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Product</th>
+            <th>Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {summary.map((s: any) => (
+            <tr key={s.product._id}>
+              <td>{s.product.listingName}</td>
+              <td>{s.count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type {
   FunctionReference,
 } from "convex/server";
 import type * as products from "../products.js";
+import type * as randomizer from "../randomizer.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -25,6 +26,7 @@ import type * as products from "../products.js";
  */
 declare const fullApi: ApiFromModules<{
   products: typeof products;
+  randomizer: typeof randomizer;
 }>;
 export declare const api: FilterApi<
   typeof fullApi,

--- a/convex/randomizer.ts
+++ b/convex/randomizer.ts
@@ -1,0 +1,54 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { Id } from "./_generated/dataModel";
+
+export const randomize = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const products = await ctx.db.query("products").collect();
+    if (products.length === 0) {
+      throw new Error("No products available");
+    }
+    const product = products[Math.floor(Math.random() * products.length)];
+    await ctx.db.insert("randomizerStats", {
+      productId: product._id as Id<"products">,
+      timestamp: Date.now(),
+    });
+    return product;
+  },
+});
+
+export const recentStats = query({
+  args: { limit: v.number() },
+  handler: async (ctx, { limit }) => {
+    const entries = await ctx.db
+      .query("randomizerStats")
+      .order("desc")
+      .take(limit);
+    const counts: Record<string, { count: number; product: any }> = {};
+    for (const e of entries) {
+      const prod = await ctx.db.get(e.productId);
+      if (!prod) continue;
+      const key = e.productId as unknown as string;
+      if (!counts[key]) counts[key] = { count: 0, product: prod };
+      counts[key].count += 1;
+    }
+    return Object.values(counts);
+  },
+});
+
+export const summaryStats = query({
+  args: {},
+  handler: async (ctx) => {
+    const entries = await ctx.db.query("randomizerStats").collect();
+    const counts: Record<string, { count: number; product: any }> = {};
+    for (const e of entries) {
+      const prod = await ctx.db.get(e.productId);
+      if (!prod) continue;
+      const key = e.productId as unknown as string;
+      if (!counts[key]) counts[key] = { count: 0, product: prod };
+      counts[key].count += 1;
+    }
+    return Object.values(counts);
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -49,4 +49,8 @@ export default defineSchema({
     gifs: v.optional(v.array(v.string())),
     videoUrls: v.optional(v.array(v.string())),
   }),
+  randomizerStats: defineTable({
+    productId: v.id("products"),
+    timestamp: v.number(),
+  }),
 });


### PR DESCRIPTION
## Summary
- add `randomizerStats` Convex table for tracking which product is selected
- implement `randomize` mutation and stats queries to expose random selection and frequency data
- create `/app/randomizer` page to trigger randomization, display result, and visualize distribution

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b46458cac832a89f78d1e373efcad