### PR TITLE
Use Convex stats instead of log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a minimal, monolithic project for managing and querying PLR Notion templ
   - SEO copy
   - Product descriptions
   - Listing metadata
+- Record run stats in Convex for scoring and analysis
 
 No frontend. No API endpoints. Just Convex + CLI.
 
@@ -34,7 +35,7 @@ convex-randomizer/
 │   ├── randomize.ts           # Script to fetch a random product from Convex
 │   └── batchRandomize.ts      # Script to fetch 20 random products from Convex
 ├── .env.local                 # Convex cloud project info
-├── logs.txt                   # Log file for the last 20 runs
+├── randomizerStats (Convex)   # Tracks run stats for scoring
 ├── package.json
 ├── tsconfig.json
 ├── README.md                  # You're reading this
@@ -109,8 +110,9 @@ Data is manually added through the [Convex Dashboard](https://dashboard.convex.d
    * Batch of 20 random products:
 
      ```bash
-     npx tsx scripts/batchRandomize.ts
-     ```
+    npx tsx scripts/batchRandomize.ts
+    ```
+   Each run is also stored in Convex via `randomizerStats.insert` to power a scoring system.
 
 4. **Use the output** in prompts for image generation, SEO writing, or markdown documentation.
 
@@ -123,7 +125,7 @@ Data is manually added through the [Convex Dashboard](https://dashboard.convex.d
 * [x] Manual data entry working
 * [x] Randomizer CLI script for single products
 * [x] Batch randomizer CLI script for 20 products
-* [x] Logging implemented with rotation
+* [x] Run stats stored via `randomizerStats.insert`
 * [x] Gemini CLI ready to consume prompt input
 
 ---

--- a/logs.txt
+++ b/logs.txt
@@ -1,5 +1,0 @@
-Timestamp: 2025-08-06T17:05:36.059Z, ID: j57a7xh4yjmw8cnyrzt5p9q1q17n4rxg, Platform: gumroad
-Timestamp: 2025-08-06T17:05:59.456Z, ID: j572jb985qqzgz2hd0deg693qs7n4gsj, Platform: gumroad
-Timestamp: 2025-08-06T17:06:23.578Z, ID: j572jb985qqzgz2hd0deg693qs7n4gsj, Platform: creativeMarket
-Timestamp: 2025-08-06T17:06:47.025Z, ID: j57c20ncmz42y2faqn2qs1d36d7n4peb, Platform: gumroad
-Timestamp: 2025-08-06T17:07:21.016Z, ID: j572jb985qqzgz2hd0deg693qs7n4gsj, Platform: etsy

--- a/scripts/randomize.ts
+++ b/scripts/randomize.ts
@@ -3,7 +3,6 @@ import { ConvexHttpClient } from "convex/browser";
 import { api } from "../convex/_generated/api.js";
 import dotenv from "dotenv";
 import path from "path";
-import fs from "fs";
 
 dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 
@@ -101,19 +100,11 @@ async function main(): Promise<void> {
 
   console.log(JSON.stringify(product, null, 2));
 
-  // Append to logs and keep only the last 20 lines
-  const logPath = path.join(process.cwd(), "logs.txt");
-  let logLines: string[] = [];
-  try {
-    const existing = fs.readFileSync(logPath, "utf-8");
-    logLines = existing.trim().split("\n").filter(Boolean);
-  } catch {
-    // no existing logs, that's fine
-  }
-
-  const newLine = `Timestamp: ${new Date().toISOString()}, ID: ${product._id ?? "unknown"}, Platform: ${(product as any).selectedPlatform}`;
-  const updated = [newLine, ...logLines].slice(0, 20).join("\n") + "\n";
-  fs.writeFileSync(logPath, updated);
+  // Record run for scoring
+  await convex.mutation(api.randomizerStats.insert, {
+    productId: product._id ?? "unknown",
+    platform: (product as any).selectedPlatform,
+  });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Record randomizer runs in Convex via `randomizerStats.insert`
- Remove `logs.txt` and its references
- Document new scoring system in README

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689b4649a730832ab472f1fd59de0825