### PR TITLE
feat: add product upsert and cleanup

### DIFF
--- a/scripts/batchRandomize.ts
+++ b/scripts/batchRandomize.ts
@@ -82,7 +82,7 @@ function warnIfMediaIncomplete(media?: MediaItem[]) {
 }
 
 async function main(): Promise<void> {
-  const products = (await convex.query(api.products.get)) as Product[];
+  const products = (await convex.query(api.products.list)) as Product[];
   if (!products || products.length === 0) {
     console.log("No products found.");
     return;

--- a/scripts/migrateLegacyToMedia.ts
+++ b/scripts/migrateLegacyToMedia.ts
@@ -74,7 +74,7 @@ async function main(): Promise<void> {
   const args = new Set(process.argv.slice(2));
   const apply = args.has("--apply");
 
-  const products = (await convex.query(api.products.get)) as Product[];
+  const products = (await convex.query(api.products.list)) as Product[];
   if (!products || products.length === 0) {
     console.log("No products found.");
     return;
@@ -117,7 +117,7 @@ async function main(): Promise<void> {
       continue;
     }
 
-    await convex.mutation(api.products.update, {
+    await convex.mutation(api.products.upsert, {
       id: product._id as any, // runtime id is fine
       patch: {
         media: mergedMedia,

--- a/scripts/randomize.ts
+++ b/scripts/randomize.ts
@@ -83,7 +83,7 @@ function warnIfMediaIncomplete(media?: MediaItem[]) {
 }
 
 async function main(): Promise<void> {
-  const products = (await convex.query(api.products.get)) as Product[];
+  const products = (await convex.query(api.products.list)) as Product[];
   if (!products || products.length === 0) {
     console.log("No products found.");
     return;


### PR DESCRIPTION
## Summary
- add `list`, `get`, `upsert`, and `remove` functions for products
- normalize and validate product fields on upsert
- update scripts to use new list and upsert helpers

## Testing
- `npx convex codegen`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b463fd14c832a82d4daf9b624c80a