### PR TITLE
Handle media arrays in product form submission

### DIFF
--- a/app/components/ProductForm.tsx
+++ b/app/components/ProductForm.tsx
@@ -11,6 +11,7 @@ export type ProductFormValues = {
   features: string[];
   categories: string[];
   tags: string[];
+  media: any[];
 };
 
 interface ProductFormProps {
@@ -39,6 +40,7 @@ export default function ProductForm({ defaultValues, onSubmit }: ProductFormProp
       features: features.split(",").map((s) => s.trim()).filter(Boolean),
       categories: categories.split(",").map((s) => s.trim()).filter(Boolean),
       tags: tags.split(",").map((s) => s.trim()).filter(Boolean),
+      media: defaultValues?.media ?? [],
     });
   };
 

--- a/app/products/[id]/page.tsx
+++ b/app/products/[id]/page.tsx
@@ -21,7 +21,7 @@ export default function EditProductPage({ params }: { params: Params }) {
   if (product === null) return <div>Not found</div>;
 
   const handleSubmit = async (values: ProductFormValues) => {
-    await update({ id, patch: values });
+    await update({ id, patch: { ...values, media: values.media ?? [] } });
     router.push(`/products/${id}`);
   };
 

--- a/app/products/new/page.tsx
+++ b/app/products/new/page.tsx
@@ -10,7 +10,7 @@ export default function NewProductPage() {
   const create = useMutation(api.products.create);
 
   const handleSubmit = async (values: ProductFormValues) => {
-    const id = await create(values);
+    const id = await create({ ...values, media: values.media ?? [] });
     router.push(`/products/${id}`);
   };
 


### PR DESCRIPTION
## Summary
- extend product form values with `media` array and include it in the submit payload, falling back to an empty array
- ensure new and edit product pages pass along media arrays when creating or updating products

## Testing
- `npm test` *(fails: no test specified)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689b5b3e12f8832ab834a70afa4d931c