### PR TITLE
docs: remove references to deleted scripts

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -13,10 +13,10 @@ It is the source of truth used by Gemini CLI and other downstream agents (Codex,
 
 ## 🎯 Project Purpose
 
-The Convex Product Randomizer is a zero-frontend, script-first system that:
+The Convex Product Randomizer is a minimal system that:
 
 - Stores PLR Notion template product data in a Convex database
-- Allows terminal scripts to fetch random products from the DB
+- Allows fetching random products from the DB
 - Randomly selects a valid marketplace platform (excluding `"N/A"`)
 - Outputs the enriched product with `selectedPlatform` and `selectedUrl`
 - Logs the result into `logs.txt` (last 20 entries only)
@@ -91,21 +91,11 @@ This project is designed for use without a frontend, and may be run on local mac
 
 ## 🔁 Randomizer Behavior
 
-**Script:** `scripts/randomize.ts`
-
 * Selects a single random product from Convex
 * Filters out platform fields with `"N/A"`
 * Picks one valid platform at random
-* Outputs `selectedPlatform` and `selectedUrl` to stdout
+* Outputs `selectedPlatform` and `selectedUrl`
 * Appends the run to `logs.txt` (max 20 entries)
-
-**Script:** `scripts/batchRandomize.ts`
-
-* Selects 20 random products (no duplicates)
-* Filters platforms as above
-* Picks one valid platform per product (or `"N/A"` if none)
-* Writes all 20 runs to `logs.txt` (replaces older entries)
-* Outputs all enriched products as a JSON array
 
 ---
 
@@ -123,7 +113,7 @@ This project is designed for use without a frontend, and may be run on local mac
 
 ## 🤖 Gemini CLI Integration
 
-The output of `randomize.ts` or `batchRandomize.ts` is passed into:
+Randomizer output is passed into:
 
 * **Makeover GPT** → Generates visual identity, themes, prompts
 * **Product Preparer GPT** → Generates SEO, instructions, categories, alt text
@@ -153,7 +143,7 @@ Gemini CLI must:
 This project is working as intended when:
 
 * Schema matches `schema.ts`
-* Scripts run without errors
+* Randomizer runs without errors
 * All randomizer outputs are valid and meet the above contracts
 * Downstream GPTs consume outputs without manual fixes
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Got it — here’s the **updated README.md** with the new `altText` + `sceneDes
 ```md
 # Convex Product Randomizer
 
-This is a minimal, monolithic project for managing and querying PLR Notion templates using Convex as a backend and terminal scripts as the interface. It is designed to run inside Replit or locally without needing a frontend or APIs.
+This is a minimal, monolithic project for managing and querying PLR Notion templates using Convex as a backend. It is designed to run inside Replit or locally without needing a complex setup.
 
 ## 📦 Purpose
 
 - Store product data (templates) manually using the Convex UI.
-- Fetch a **random product** or a **batch of 20 random products** using terminal scripts.
+- Fetch a **random product** from Convex.
 - Pass the random product(s) to AI tools like Gemini CLI or Codex for generating:
   - Image prompts
   - SEO copy
@@ -18,7 +18,7 @@ This is a minimal, monolithic project for managing and querying PLR Notion templ
   - Listing metadata
 - Record run stats in Convex for scoring and analysis
 
-No frontend. No API endpoints. Just Convex + CLI.
+Minimal Next.js frontend with Convex as the backend.
 
 ---
 
@@ -31,9 +31,7 @@ convex-randomizer/
 │   ├── schema.ts              # Product schema definition
 │   ├── products.ts            # Query to get all products
 │   └── \_generated/            # Convex auto-generated files
-├── scripts/
-│   ├── randomize.ts           # Script to fetch a random product from Convex
-│   └── batchRandomize.ts      # Script to fetch 20 random products from Convex
+├── app/                      # Next.js app (randomizer page)
 ├── .env.local                 # Convex cloud project info
 ├── randomizerStats (Convex)   # Tracks run stats for scoring
 ├── package.json
@@ -100,18 +98,7 @@ Data is manually added through the [Convex Dashboard](https://dashboard.convex.d
 
 2. **Insert products** through the dashboard UI.
 
-3. **Run the randomizer scripts:**
-
-   * Single random product:
-
-     ```bash
-     npx tsx scripts/randomize.ts
-     ```
-   * Batch of 20 random products:
-
-     ```bash
-    npx tsx scripts/batchRandomize.ts
-    ```
+3. **Use the randomizer page** to fetch a random product.
    Each run is also stored in Convex via `randomizerStats.insert` to power a scoring system.
 
 4. **Use the output** in prompts for image generation, SEO writing, or markdown documentation.
@@ -123,8 +110,6 @@ Data is manually added through the [Convex Dashboard](https://dashboard.convex.d
 * [x] Schema defined with `altText` and `sceneDescription` required for all media items
 * [x] Dev server working
 * [x] Manual data entry working
-* [x] Randomizer CLI script for single products
-* [x] Batch randomizer CLI script for 20 products
 * [x] Run stats stored via `randomizerStats.insert`
 * [x] Gemini CLI ready to consume prompt input
 


### PR DESCRIPTION
## Summary
- drop stale mentions of old CLI scripts
- point README to the randomizer page
- clarify randomizer behavior in GEMINI

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b5b401104832a8c36a5d48ab4ecba