### PR TITLE
Add product selection export

### DIFF
--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,14 +1,37 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
+import { downloadJson } from "../utils/downloadJson";
 
 export default function ProductsPage() {
   const products = useQuery(api.products.list);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const toggle = (id: string) => {
+    setSelected((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const handleExport = () => {
+    const selectedProducts =
+      products?.filter((p) => selected.includes(p._id as string)) ?? [];
+    downloadJson(selectedProducts, "products.json");
+  };
+
   return (
     <div className="p-4">
-      <div className="flex justify-end mb-4">
+      <div className="flex justify-between mb-4">
+        <button
+          onClick={handleExport}
+          disabled={selected.length === 0}
+          className="border px-2 py-1 rounded disabled:opacity-50"
+        >
+          Export Selected
+        </button>
         <Link href="/products/new" className="border px-2 py-1 rounded">
           New
         </Link>
@@ -16,6 +39,9 @@ export default function ProductsPage() {
       <table className="w-full border-collapse">
         <thead>
           <tr>
+            <th className="border p-2">
+              <span className="sr-only">Select</span>
+            </th>
             <th className="border p-2 text-left">Listing Name</th>
             <th className="border p-2 text-left">Official Name</th>
             <th className="border p-2 text-left">Categories</th>
@@ -26,6 +52,13 @@ export default function ProductsPage() {
         <tbody>
           {products?.map((p) => (
             <tr key={p._id as string}>
+              <td className="border p-2 text-center">
+                <input
+                  type="checkbox"
+                  checked={selected.includes(p._id as string)}
+                  onChange={() => toggle(p._id as string)}
+                />
+              </td>
               <td className="border p-2">{p.listingName}</td>
               <td className="border p-2">{p.officialName}</td>
               <td className="border p-2">{p.categories?.join(", ")}</td>

--- a/app/utils/downloadJson.ts
+++ b/app/utils/downloadJson.ts
@@ -1,0 +1,10 @@
+export function downloadJson(data: unknown, filename = "data.json") {
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add downloadJson utility to trigger JSON downloads
- enable selecting products via checkbox and exporting to JSON

## Testing
- `npm test`
- `npm run typecheck`
- `npm run build` (fails: Module not found: Can't resolve './globals.css')


------
https://chatgpt.com/codex/tasks/task_e_689b8939d8d8832ab7639327c09779c5