### PR TITLE
feat: add health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Data is manually added through the [Convex Dashboard](https://dashboard.convex.d
 
 4. **Use the output** in prompts for image generation, SEO writing, or markdown documentation.
 
+## 🩺 Health Check
+
+The endpoint `/api/health` returns `{ "ok": true }` and can be used by deployment monitoring services to verify the app is running.
+
 ---
 
 ## ✅ Done

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return Response.json({ ok: true });
+}


### PR DESCRIPTION
## Summary
- add `/api/health` route for uptime monitoring
- document health check endpoint in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ba0b39244832a88554c7bf63d4eb1