### PR TITLE
Use NEXT_PUBLIC_CONVEX_URL for Convex client config

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,4 +1,4 @@
 # Deployment used by `npx convex dev`
 CONVEX_DEPLOYMENT=dev:polite-panther-3 # team: tankiso-mpela, project: tabkiso-mpela
 
-CONVEX_URL=https://polite-panther-3.convex.cloud
+NEXT_PUBLIC_CONVEX_URL=https://polite-panther-3.convex.cloud

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ convex-randomizer/
 
 ---
 
+## 🔑 Environment Variables
+
+Define the Convex deployment URL in `.env.local` using the `NEXT_PUBLIC_CONVEX_URL` key so it is available to the browser:
+
+```bash
+NEXT_PUBLIC_CONVEX_URL=https://your-deployment.convex.cloud
+```
+
+Client-side code should reference this via `process.env.NEXT_PUBLIC_CONVEX_URL`. The `CONVEX_DEPLOYMENT` variable may remain for the Convex CLI but is not used in frontend code.
+
+---
+
 ## 🧠 Schema Overview
 
 Each product in Convex includes:


### PR DESCRIPTION
## Summary
- expose Convex deployment URL through NEXT_PUBLIC_CONVEX_URL
- document NEXT_PUBLIC_CONVEX_URL usage in README

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ba0b09d0c832a870cab1c99e7a90f