### PR TITLE
Add robots meta header middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export function middleware(req: NextRequest) {
+  const res = NextResponse.next();
+
+  if (req.nextUrl.pathname.startsWith('/admin')) {
+    res.headers.set('X-Robots-Tag', 'noindex, nofollow');
+  }
+
+  return res;
+}


### PR DESCRIPTION
## Summary
- add Next.js middleware to set `X-Robots-Tag: noindex, nofollow` for `/admin` routes

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ba0af75c0832a9fec1c737f990117