### PR TITLE
Add JSON import/export for products

### DIFF
--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
-import { useQuery } from "convex/react";
+import { useState, ChangeEvent } from "react";
+import { useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { downloadJson } from "../utils/downloadJson";
 
 export default function ProductsPage() {
   const products = useQuery(api.products.list);
+  const seed = useMutation(api.products.seed);
   const [selected, setSelected] = useState<string[]>([]);
 
   const toggle = (id: string) => {
@@ -16,22 +17,61 @@ export default function ProductsPage() {
     );
   };
 
-  const handleExport = () => {
+  const handleExportAll = () => {
+    downloadJson(products ?? [], "products.json");
+  };
+
+  const handleExportSelected = () => {
     const selectedProducts =
       products?.filter((p) => selected.includes(p._id as string)) ?? [];
     downloadJson(selectedProducts, "products.json");
   };
 
+  const handleImport = async (
+    e: ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const data = JSON.parse(text);
+    if (Array.isArray(data)) {
+      await seed({ products: data });
+    }
+    e.target.value = ""; // reset for subsequent imports
+  };
+
   return (
     <div className="p-4">
       <div className="flex justify-between mb-4">
-        <button
-          onClick={handleExport}
-          disabled={selected.length === 0}
-          className="border px-2 py-1 rounded disabled:opacity-50"
-        >
-          Export Selected
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={handleExportAll}
+            disabled={!products?.length}
+            className="border px-2 py-1 rounded disabled:opacity-50"
+          >
+            Export JSON
+          </button>
+          <button
+            onClick={handleExportSelected}
+            disabled={selected.length === 0}
+            className="border px-2 py-1 rounded disabled:opacity-50"
+          >
+            Export Selected
+          </button>
+          <label
+            htmlFor="import-json"
+            className="border px-2 py-1 rounded cursor-pointer"
+          >
+            Import JSON
+          </label>
+          <input
+            id="import-json"
+            type="file"
+            accept="application/json"
+            onChange={handleImport}
+            className="hidden"
+          />
+        </div>
         <Link href="/products/new" className="border px-2 py-1 rounded">
           New
         </Link>

--- a/convex/products.ts
+++ b/convex/products.ts
@@ -81,3 +81,21 @@ export const remove = mutation({
     return { ok: true };
   },
 });
+
+export const seed = mutation({
+  args: { products: v.array(v.object(baseArgs)) },
+  handler: async (ctx, { products }) => {
+    const ids: Id<"products">[] = [];
+    for (const product of products) {
+      const copy = { ...product } as any;
+      trimAndOmitEmpty(copy);
+      ids.push(
+        await ctx.db.insert("products", {
+          ...copy,
+          media: copy.media ?? [],
+        })
+      );
+    }
+    return ids;
+  },
+});


### PR DESCRIPTION
## Summary
- add export all and import JSON controls to products page
- support bulk product seeding via new Convex mutation

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ba0ad25b0832a90ad28f3590e3318