### PR TITLE
feat: add deterministic seed support

### DIFF
--- a/app/randomizer/page.tsx
+++ b/app/randomizer/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useMutation, useQuery } from "convex/react";
+import { useSearchParams } from "next/navigation";
 import { api } from "../../convex/_generated/api";
 
 const PLATFORM_KEYS = [
@@ -20,9 +21,11 @@ export default function RandomizerPage() {
   const recent = useQuery(api.randomizer.recentStats, { limit: 20 }) || [];
   const summary = useQuery(api.randomizer.summaryStats) || [];
   const [current, setCurrent] = useState<any>(null);
+  const searchParams = useSearchParams();
+  const seed = searchParams.get("seed") ?? undefined;
 
   const run = async () => {
-    const result = await randomize();
+    const result = await randomize(seed ? { seed } : {});
     setCurrent(result);
   };
 


### PR DESCRIPTION
## Summary
- allow randomizer.randomize to accept optional seed and deterministically choose a product
- read `seed` from URL query in the randomizer page and pass to mutation

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ba09e05f4832a8028e138616ea4cf