### PR TITLE
Remove unused randomizer analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ This is a minimal, monolithic project for managing and querying PLR Notion templ
   - SEO copy
   - Product descriptions
   - Listing metadata
-- Record run stats in Convex for scoring and analysis
 
 Minimal Next.js frontend with Convex as the backend.
 
@@ -33,7 +32,6 @@ convex-randomizer/
 │   └── \_generated/            # Convex auto-generated files
 ├── app/                      # Next.js app (randomizer page)
 ├── .env.local                 # Convex cloud project info
-├── randomizerStats (Convex)   # Tracks run stats for scoring
 ├── package.json
 ├── tsconfig.json
 ├── README.md                  # You're reading this
@@ -99,7 +97,6 @@ Data is manually added through the [Convex Dashboard](https://dashboard.convex.d
 2. **Insert products** through the dashboard UI.
 
 3. **Use the randomizer page** to fetch a random product.
-   Each run is also stored in Convex via `randomizerStats.insert` to power a scoring system.
 
 4. **Use the output** in prompts for image generation, SEO writing, or markdown documentation.
 
@@ -110,7 +107,6 @@ Data is manually added through the [Convex Dashboard](https://dashboard.convex.d
 * [x] Schema defined with `altText` and `sceneDescription` required for all media items
 * [x] Dev server working
 * [x] Manual data entry working
-* [x] Run stats stored via `randomizerStats.insert`
 * [x] Gemini CLI ready to consume prompt input
 
 ---

--- a/app/randomizer/page.tsx
+++ b/app/randomizer/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 
 const PLATFORM_KEYS = [
@@ -17,8 +17,6 @@ const PLATFORM_KEYS = [
 
 export default function RandomizerPage() {
   const randomize = useMutation(api.randomizer.randomize);
-  const recent = useQuery(api.randomizer.recentStats, { limit: 20 }) || [];
-  const summary = useQuery(api.randomizer.summaryStats) || [];
   const [current, setCurrent] = useState<any>(null);
 
   const run = async () => {
@@ -29,10 +27,6 @@ export default function RandomizerPage() {
   const platform =
     current &&
     PLATFORM_KEYS.map((k) => (current as any)[k]).find((v) => v != null);
-
-  const score =
-    current &&
-    (recent.find((r: any) => r.product._id === current._id)?.count || 0);
 
   return (
     <div>
@@ -45,26 +39,8 @@ export default function RandomizerPage() {
               Platform: <a href={platform}>{platform}</a>
             </p>
           )}
-          <p>Score (last 20): {score}</p>
         </div>
       )}
-      <h3>Health</h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Product</th>
-            <th>Count</th>
-          </tr>
-        </thead>
-        <tbody>
-          {summary.map((s: any) => (
-            <tr key={s.product._id}>
-              <td>{s.product.listingName}</td>
-              <td>{s.count}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
     </div>
   );
 }

--- a/convex/randomizer.ts
+++ b/convex/randomizer.ts
@@ -1,6 +1,4 @@
-import { mutation, query } from "./_generated/server";
-import { v } from "convex/values";
-import { Id } from "./_generated/dataModel";
+import { mutation } from "./_generated/server";
 
 export const randomize = mutation({
   args: {},
@@ -10,45 +8,6 @@ export const randomize = mutation({
       throw new Error("No products available");
     }
     const product = products[Math.floor(Math.random() * products.length)];
-    await ctx.db.insert("randomizerStats", {
-      productId: product._id as Id<"products">,
-      timestamp: Date.now(),
-    });
     return product;
-  },
-});
-
-export const recentStats = query({
-  args: { limit: v.number() },
-  handler: async (ctx, { limit }) => {
-    const entries = await ctx.db
-      .query("randomizerStats")
-      .order("desc")
-      .take(limit);
-    const counts: Record<string, { count: number; product: any }> = {};
-    for (const e of entries) {
-      const prod = await ctx.db.get(e.productId);
-      if (!prod) continue;
-      const key = e.productId as unknown as string;
-      if (!counts[key]) counts[key] = { count: 0, product: prod };
-      counts[key].count += 1;
-    }
-    return Object.values(counts);
-  },
-});
-
-export const summaryStats = query({
-  args: {},
-  handler: async (ctx) => {
-    const entries = await ctx.db.query("randomizerStats").collect();
-    const counts: Record<string, { count: number; product: any }> = {};
-    for (const e of entries) {
-      const prod = await ctx.db.get(e.productId);
-      if (!prod) continue;
-      const key = e.productId as unknown as string;
-      if (!counts[key]) counts[key] = { count: 0, product: prod };
-      counts[key].count += 1;
-    }
-    return Object.values(counts);
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -49,8 +49,4 @@ export default defineSchema({
     gifs: v.optional(v.array(v.string())),
     videoUrls: v.optional(v.array(v.string())),
   }),
-  randomizerStats: defineTable({
-    productId: v.id("products"),
-    timestamp: v.number(),
-  }),
 });


### PR DESCRIPTION
## Summary
- drop `randomizerStats` table and related inserts/queries
- simplify randomizer UI to only fetch a product
- clean up README references to run stats

## Testing
- `npm run codegen`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ba09799e0832abc59f20a3b56c75c