### PR TITLE
Add published flag to products and filter randomizer

### DIFF
--- a/convex/products.ts
+++ b/convex/products.ts
@@ -34,6 +34,7 @@ const baseArgs = {
   categories: v.array(v.string()),
   tags: v.array(v.string()),
   media: v.optional(v.array(v.any())),
+  published: v.optional(v.boolean()),
 };
 
 export const list = query({ args: {}, handler: (ctx) => ctx.db.query("products").collect() });
@@ -44,7 +45,11 @@ export const create = mutation({
   args: baseArgs,
   handler: async (ctx, args) => {
     trimAndOmitEmpty(args as any);
-    return await ctx.db.insert("products", { ...args, media: args.media ?? [] });
+    return await ctx.db.insert("products", {
+      ...args,
+      media: args.media ?? [],
+      published: args.published ?? false,
+    });
   },
 });
 
@@ -62,6 +67,7 @@ export const update = mutation({
       categories: v.optional(v.array(v.string())),
       tags: v.optional(v.array(v.string())),
       media: v.optional(v.array(v.any())),
+      published: v.optional(v.boolean()),
     }),
   },
   handler: async (ctx, { id, patch }) => {

--- a/convex/randomizer.ts
+++ b/convex/randomizer.ts
@@ -5,7 +5,22 @@ import { Id } from "./_generated/dataModel";
 export const randomize = mutation({
   args: {},
   handler: async (ctx) => {
-    const products = await ctx.db.query("products").collect();
+    const products = await ctx.db
+      .query("products")
+      .withIndex("by_published", (q) => q.eq("published", true))
+      .filter((q) =>
+        q.or(
+          q.neq(q.field("gumroadUrl"), undefined),
+          q.neq(q.field("etsyUrl"), undefined),
+          q.neq(q.field("creativeMarketUrl"), undefined),
+          q.neq(q.field("notionUrl"), undefined),
+          q.neq(q.field("notionery"), undefined),
+          q.neq(q.field("notionEverything"), undefined),
+          q.neq(q.field("prototion"), undefined),
+          q.neq(q.field("notionLand"), undefined)
+        )
+      )
+      .collect();
     if (products.length === 0) {
       throw new Error("No products available");
     }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -26,6 +26,8 @@ export default defineSchema({
     categories: v.array(v.string()),
     tags: v.array(v.string()),
 
+    published: v.boolean(),
+
     // Canonical media store (mandatory complements)
     media: v.array(
       v.object({
@@ -48,7 +50,7 @@ export default defineSchema({
     screenshots: v.optional(v.array(v.string())),
     gifs: v.optional(v.array(v.string())),
     videoUrls: v.optional(v.array(v.string())),
-  }),
+  }).index("by_published", ["published"]),
   randomizerStats: defineTable({
     productId: v.id("products"),
     timestamp: v.number(),


### PR DESCRIPTION
## Summary
- track whether a product is published in schema with an index on that field
- expose optional `published` flag in product create/update mutations with default `false`
- randomizer now draws only from published products that list at least one platform URL

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ba096286c832a93d6cdec06b13866