### PR TITLE
chore: drop legacy media arrays from schema

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -43,11 +43,6 @@ export default defineSchema({
       })
     ),
 
-    // Legacy arrays (for migration only; remove after backfill)
-    imagePolished: v.optional(v.array(v.string())),
-    screenshots: v.optional(v.array(v.string())),
-    gifs: v.optional(v.array(v.string())),
-    videoUrls: v.optional(v.array(v.string())),
   }),
   randomizerStats: defineTable({
     productId: v.id("products"),


### PR DESCRIPTION
## Summary
- remove legacy media arrays from Convex schema
- regenerate Convex types

## Testing
- `npx convex codegen`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ba08d751c832aa29689026deadc81