### PR TITLE
Add Convex root provider to Next.js layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,15 @@
 import "./globals.css";
 import { ReactNode } from "react";
 import AuthGate from "./components/AuthGate";
+import { ConvexRootProvider } from "../lib/convexClient";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <AuthGate>{children}</AuthGate>
+        <AuthGate>
+          <ConvexRootProvider>{children}</ConvexRootProvider>
+        </AuthGate>
       </body>
     </html>
   );

--- a/lib/convexClient.ts
+++ b/lib/convexClient.ts
@@ -1,0 +1,9 @@
+import { ReactNode, createElement } from "react";
+import { ConvexProvider, ConvexReactClient } from "convex/react";
+
+const client = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+export function ConvexRootProvider({ children }: { children: ReactNode }) {
+  return createElement(ConvexProvider, { client, children });
+}
+


### PR DESCRIPTION
## Summary
- add ConvexRootProvider thin wrapper around ConvexProvider
- wrap root layout children with ConvexRootProvider

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ba086d5e0832ab926ebba6b5af8ac