### PR TITLE
refactor: centralize Convex client

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,4 +1,4 @@
 # Deployment used by `npx convex dev`
-CONVEX_DEPLOYMENT=dev:polite-panther-3 # team: tankiso-mpela, project: tabkiso-mpela
 
-CONVEX_URL=https://polite-panther-3.convex.cloud
+# Public Convex deployment URL
+NEXT_PUBLIC_CONVEX_URL=https://polite-panther-3.convex.cloud

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,15 @@
 import "./globals.css";
 import { ReactNode } from "react";
 import AuthGate from "./components/AuthGate";
+import { ConvexProvider, convex } from "../lib/convexClient";
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <AuthGate>{children}</AuthGate>
+        <ConvexProvider client={convex}>
+          <AuthGate>{children}</AuthGate>
+        </ConvexProvider>
       </body>
     </html>
   );

--- a/app/products/[id]/page.tsx
+++ b/app/products/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useQuery, useMutation } from "convex/react";
+import { useQuery, useMutation } from "../../../lib/convexClient";
 import { api } from "../../../convex/_generated/api";
 import { Id } from "../../../convex/_generated/dataModel";
 import ProductForm, { ProductFormValues } from "../../components/ProductForm";

--- a/app/products/new/page.tsx
+++ b/app/products/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useMutation } from "convex/react";
+import { useMutation } from "../../../lib/convexClient";
 import { api } from "../../../convex/_generated/api";
 import ProductForm, { ProductFormValues } from "../../components/ProductForm";
 

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { useQuery } from "convex/react";
+import { useQuery } from "../../lib/convexClient";
 import { api } from "../../convex/_generated/api";
 import { downloadJson } from "../utils/downloadJson";
 

--- a/app/randomizer/page.tsx
+++ b/app/randomizer/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation, useQuery } from "../../lib/convexClient";
 import { api } from "../../convex/_generated/api";
 
 const PLATFORM_KEYS = [

--- a/lib/convexClient.ts
+++ b/lib/convexClient.ts
@@ -1,0 +1,5 @@
+import { ConvexReactClient, ConvexProvider, useQuery, useMutation } from "convex/react";
+
+export const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+export { ConvexProvider, useQuery, useMutation };


### PR DESCRIPTION
## Summary
- use NEXT_PUBLIC_CONVEX_URL env var and drop CONVEX_DEPLOYMENT
- centralize Convex client, provider and hooks in lib/convexClient.ts
- update layout and pages to import Convex hooks from the shared client

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ba0746a98832aa8011b6bc9e969c7